### PR TITLE
add more supported terminals like zutty and unprivileged view of auto-upgrade logs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,10 +4,11 @@ apt-notifier (24.04.01) mx; urgency=medium
   * Suppress first blank line in the terminal
   * Add terminal support for lxterminal, mate-terminal, qterminal,
     terminator and zutty
-  * Check qterminal version is recent enough
-  * Use of xfce4 terminal as fallback if installed
+  * Check whether the qterminal version is up-to-date enough
+  * Use of the xfce4 terminal as a fallback, if installed
+  * Adjust unprivileged view of the auto-upgrade logs
 
- -- fehlix <fehlix@mxlinux.org>  Wed, 24 Apr 2024 17:14:17 -0400
+ -- fehlix <fehlix@mxlinux.org>  Thu, 25 Apr 2024 20:53:31 -0400
 
 apt-notifier (24.03.01) mx; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+apt-notifier (24.04.01) mx; urgency=medium
+
+  * Add line break in the countdown line for smaller display size
+  * Suppress first blank line in the terminal
+  * Add terminal support for lxterminal, mate-terminal, qterminal,
+    terminator and zutty
+  * Check qterminal version is recent enough
+  * Use of xfce4 terminal as fallback if installed
+
+ -- fehlix <fehlix@mxlinux.org>  Wed, 24 Apr 2024 17:14:17 -0400
+
 apt-notifier (24.03.01) mx; urgency=medium
 
   * generate svg iconset with rsvg-convert instead of inkscape

--- a/debian/install
+++ b/debian/install
@@ -9,6 +9,7 @@ conf/51unattended-upgrades-origins                                usr/share/apt-
 icons/build/icons                                                 usr/share
 lib/actions/auto-update                                           usr/lib/apt-notifier/actions
 lib/actions/updater_action                                        usr/lib/apt-notifier/actions
+lib/actions/unattended_upgrades_log                               usr/lib/apt-notifier/actions
 lib/bin/updater_config                                            usr/lib/apt-notifier/bin
 lib/bin/updater_count                                             usr/lib/apt-notifier/bin
 lib/bin/updater_list                                              usr/lib/apt-notifier/bin
@@ -38,6 +39,8 @@ lib/policy/org.mxlinux.apt-notifier.full-upgrade_run.policy       usr/share/polk
 lib/policy/org.mxlinux.apt-notifier.reload.policy                 usr/share/polkit-1/actions
 lib/policy/org.mxlinux.apt-notifier.reload_run.policy             usr/share/polkit-1/actions
 lib/policy/org.mxlinux.apt-notifier.lslocks.policy                usr/share/polkit-1/actions
+lib/policy/org.mxlinux.apt-notifier.unattended_upgrades_dpkg_log_view.policy   usr/share/polkit-1/actions
+lib/policy/org.mxlinux.apt-notifier.unattended_upgrades_log_view.policy        usr/share/polkit-1/actions
 lib/shlib/updater_aptpref                                         usr/lib/apt-notifier/shlib
 lib/shlib/updater_shlib                                           usr/lib/apt-notifier/shlib
 license.html                                                      usr/share/doc/apt-notifier

--- a/debian/links
+++ b/debian/links
@@ -1,12 +1,12 @@
-usr/lib/apt-notifier/actions/auto-update            usr/lib/apt-notifier/actions/auto-update-disable
-usr/lib/apt-notifier/actions/auto-update            usr/lib/apt-notifier/actions/auto-update-enable
-usr/lib/apt-notifier/actions/updater_action         usr/lib/apt-notifier/actions/updater_basic-upgrade_action
-usr/lib/apt-notifier/actions/updater_action         usr/lib/apt-notifier/actions/updater_full-upgrade_action
-usr/lib/apt-notifier/actions/updater_action         usr/lib/apt-notifier/actions/updater_reload_action
-usr/lib/actions/unattended_upgrades_dpkg_log        usr/lib/actions/unattended_upgrades_log
-usr/lib/apt-notifier/bin/updater_upgrade_run        usr/lib/apt-notifier/bin/updater_basic-upgrade_run
-usr/lib/apt-notifier/bin/updater_upgrade_run        usr/lib/apt-notifier/bin/updater_full-upgrade_run
-usr/share/apt-notifier/1-quick-live-update          etc/cron.daily/1-quick-live-update
-usr/share/apt-notifier/2-apt-compat                 etc/cron.daily/2-apt-compat
-usr/share/apt-notifier/03apt-notifier-update-stamp  etc/apt/apt.conf.d/03apt-notifier-update-stamp
+usr/lib/apt-notifier/actions/auto-update              usr/lib/apt-notifier/actions/auto-update-disable
+usr/lib/apt-notifier/actions/auto-update              usr/lib/apt-notifier/actions/auto-update-enable
+usr/lib/apt-notifier/actions/updater_action           usr/lib/apt-notifier/actions/updater_basic-upgrade_action
+usr/lib/apt-notifier/actions/updater_action           usr/lib/apt-notifier/actions/updater_full-upgrade_action
+usr/lib/apt-notifier/actions/updater_action           usr/lib/apt-notifier/actions/updater_reload_action
+usr/lib/apt-notifier/actions/unattended_upgrades_log  usr/lib/apt-notifier/actions/unattended_upgrades_dpkg_log
+usr/lib/apt-notifier/bin/updater_upgrade_run          usr/lib/apt-notifier/bin/updater_basic-upgrade_run
+usr/lib/apt-notifier/bin/updater_upgrade_run          usr/lib/apt-notifier/bin/updater_full-upgrade_run
+usr/share/apt-notifier/1-quick-live-update            etc/cron.daily/1-quick-live-update
+usr/share/apt-notifier/2-apt-compat                   etc/cron.daily/2-apt-compat
+usr/share/apt-notifier/03apt-notifier-update-stamp    etc/apt/apt.conf.d/03apt-notifier-update-stamp
 

--- a/debian/links
+++ b/debian/links
@@ -3,8 +3,10 @@ usr/lib/apt-notifier/actions/auto-update            usr/lib/apt-notifier/actions
 usr/lib/apt-notifier/actions/updater_action         usr/lib/apt-notifier/actions/updater_basic-upgrade_action
 usr/lib/apt-notifier/actions/updater_action         usr/lib/apt-notifier/actions/updater_full-upgrade_action
 usr/lib/apt-notifier/actions/updater_action         usr/lib/apt-notifier/actions/updater_reload_action
+usr/lib/actions/unattended_upgrades_dpkg_log        usr/lib/actions/unattended_upgrades_log
 usr/lib/apt-notifier/bin/updater_upgrade_run        usr/lib/apt-notifier/bin/updater_basic-upgrade_run
 usr/lib/apt-notifier/bin/updater_upgrade_run        usr/lib/apt-notifier/bin/updater_full-upgrade_run
 usr/share/apt-notifier/1-quick-live-update          etc/cron.daily/1-quick-live-update
 usr/share/apt-notifier/2-apt-compat                 etc/cron.daily/2-apt-compat
 usr/share/apt-notifier/03apt-notifier-update-stamp  etc/apt/apt.conf.d/03apt-notifier-update-stamp
+

--- a/lib/actions/unattended_upgrades_dpkg_log
+++ b/lib/actions/unattended_upgrades_dpkg_log
@@ -1,0 +1,1 @@
+unattended_upgrades_log

--- a/lib/actions/unattended_upgrades_log
+++ b/lib/actions/unattended_upgrades_log
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ME=$0
+
+LOG_VIEW=/usr/bin/apt-notifier_"${ME##*/}"_view
+
+# switch to root
+(( $(id -u) )) && exec pkexec "$LOG_VIEW" 
+
+$LOG_VIEW
+
+exit 0

--- a/lib/modules/aptnotifier_autoupdate.py
+++ b/lib/modules/aptnotifier_autoupdate.py
@@ -143,7 +143,7 @@ class UnattendedUpgrade:
         yad = yad.splitlines()
         yad = [ x.strip().format(**self.__tokens) for x in yad ]
 
-        cmd  = "apt-notifier_unattended_upgrades_log_view"
+        cmd  = "/usr/lib/apt-notifier/actions/unattended_upgrades_log"
         pipe1 = Popen(cmd, stdout=PIPE, text=True)
         pipe2 = Popen(yad, stdin=pipe1.stdout, stdout=PIPE, stderr=PIPE, text=True)
         pipe1.stdout.close()  # if pipe2 exits before pipe1, send SIGPIPE to pipe1 to close
@@ -173,7 +173,7 @@ class UnattendedUpgrade:
         yad = yad.splitlines()
         yad = [ x.strip().format(**self.__tokens) for x in yad ]
 
-        cmd  = "apt-notifier_unattended_upgrades_dpkg_log_view"
+        cmd  = "/usr/lib/apt-notifier/actions/unattended_upgrades_dpkg_log"
         pipe1 = Popen(cmd, stdout=PIPE, text=True)
         pipe2 = Popen(yad, stdin=pipe1.stdout, stdout=PIPE, stderr=PIPE, text=True)
         pipe1.stdout.close()  # if pipe2 exits before pipe1, send SIGPIPE to pipe1 to close

--- a/lib/policy/org.mxlinux.apt-notifier.unattended_upgrades_dpkg_log_view.policy
+++ b/lib/policy/org.mxlinux.apt-notifier.unattended_upgrades_dpkg_log_view.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<!--
+    /usr/share/polkit-1/actions/org.mxlinux.apt-notifier.unattended_upgrades_dpkg_log_view.policy
+!-->
+ <policyconfig>
+  <vendor>MX Linux</vendor>
+  <vendor_url>https://mxlinux.org</vendor_url>
+  <action id="org.mxlinux.apt-notifier.unattended_upgrades_dpkg_log_view">
+    <description>Run MX Linux application</description>
+    <message gettext-domain="apt-notifier">Reload</message>
+    <icon_name>apt-notifier</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/apt-notifier_unattended_upgrades_dpkg_log_view</annotate>
+  </action>
+</policyconfig>

--- a/lib/policy/org.mxlinux.apt-notifier.unattended_upgrades_log_view.policy
+++ b/lib/policy/org.mxlinux.apt-notifier.unattended_upgrades_log_view.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<!--
+    /usr/share/polkit-1/actions/org.mxlinux.apt-notifier.unattended_upgrades_log_view.policy
+!-->
+ <policyconfig>
+  <vendor>MX Linux</vendor>
+  <vendor_url>https://mxlinux.org</vendor_url>
+  <action id="org.mxlinux.apt-notifier.unattended_upgrades_log_view">
+    <description>Run MX Linux application</description>
+    <message gettext-domain="apt-notifier">Reload</message>
+    <icon_name>apt-notifier</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/apt-notifier_unattended_upgrades_log_view</annotate>
+  </action>
+</policyconfig>

--- a/lib/shlib/updater_shlib
+++ b/lib/shlib/updater_shlib
@@ -9,7 +9,6 @@
 # this bash scripted is meant to be "sourced"
 # at /usr/lib/apt-notifier/lib/updater_shlib
 
-
 press_any_key_stop_auto_close() {
 
     local default_timeout=10
@@ -40,6 +39,10 @@ press_any_key_stop_auto_close() {
     local cntd_line
     local cntd_space_line
 
+    local break_line="false"
+    (( count_len + 3 + ${#anykey_to_stop} + 20 >= cols )) && break_line="true"
+
+    if $break_line; then  echo "$anykey_to_stop"; fi
     i=0
     (( count_timeout < 1 )) &&  count_timeout=1
     while (( i++ <  count_timeout+1)); do
@@ -47,7 +50,12 @@ press_any_key_stop_auto_close() {
         (( spc_len = count_len - count_str_len ))
         cntd_line="${count_line:0:$count_str_len}";
         cntd_done_line="${done_line:0:$spc_len}"
-        printf $'\r'"%${length_timeout}i ${cntd_line}${cntd_done_line}: $anykey_to_stop" $count_down;
+        if $break_line; then
+           printf $'\r'"${cntd_line}${cntd_done_line}: %${length_timeout}i" $count_down;
+        else
+           printf $'\r'"%${length_timeout}i ${cntd_line}${cntd_done_line}: $anykey_to_stop" $count_down;
+        fi
+
         (( count_down = count_timeout-i))
         read -sr -t1 -n1 && break;
     done && printf $'\r'"$space_line" || return 0
@@ -63,10 +71,9 @@ press_any_key_to_close() {
     cls_msg=${cls_msg^}
     # add ellipses
     cls_msg="${cls_msg^}..."
-    read -rsn 1 -p $'\r'"$cls_msg" -t 999999999
+    read -rsn 1 -p $'\r'"$cls_msg" -t 999999
     return 0
 }
-
 
 translate() {
     local text="$1"
@@ -110,7 +117,7 @@ updater_show() {
     if ((DW >= 1600)); then
         TW=$(( 1600 * 3 / 5 ))
         TH=$((  900 * 2 / 3 ))
-    fi 
+    fi
     read -r XOFF YOFF < <(xrandr | sed -n -r '/connected primary/{/.*[0-9]+x[0-9]+\+([0-9]+)\+([0-9]+).*/{s::\1 \2:p;q}}')
 
     : ${XOFF:=0}
@@ -118,7 +125,6 @@ updater_show() {
 
     TX=$(((DW-TW)/2 + XOFF))
     TY=$(((DH-TH)/2 + YOFF))
-
 
     XSEARCH="xdotool sleep 0.2 search --onlyvisible --name '$T'"
     XSIZE="windowsize $TW $TH"
@@ -128,23 +134,41 @@ updater_show() {
 
     XDO="$XSEARCH $XSIZE $XMOVE $XCLASS"
 
-
     CW=10 # char width - rough default
     CH=20 # char hight - rough default
 
-    #G="--geometry=$(($TW/$CW))x$(($TH/$CH))+$TX+$TY"
     G="$(($TW/$CW))x$(($TH/$CH))+$TX+$TY"
 
     SLEEP=0.3 # sleep
 
-    C='bash -c "echo '"$msg"'; sleep 0.5;'" $XDO;"' '"$RUN"'"'
-    K='bash -c "echo '"$msg"'; sleep 1; '"$RUN"'"'
+    C='bash -c "test -n '"'${msg}'"' && echo '"'$msg'"'; sleep 0.5;'" $XDO;"' '"${cmd}"'"'
+    K='bash -c "test -n '"'${msg}'"' && echo '"'$msg'"'; sleep 1; '"${cmd}"'"'
 
+    XTE=$(readlink -e /usr/bin/x-terminal-emulator)
 
-    case $(readlink -e /usr/bin/x-terminal-emulator) in
+    # check whether the installed qterminal version is up-to-date enough
+    if [ -z "${XTE##*qterminal*}" ]; then
+       CUR_QTV=$(dpkg-query -f '${Version}' -W qterminal 2>/dev/null)
+       MIN_QTV="1.2.0"
+       # compare versions
+       if dpkg --compare-versions "$CUR_QTV" lt  "$MIN_QTV"; then
+            if [ -x /usr/bin/xfce4-terminal ]; then
+                # use xfce4-terminal if installed
+                XTE=usr/bin/xfce4-terminal
+            else
+                # use best alternative
+                XTE=$(update-alternatives --display x-terminal-emulator | \
+                    grep '^/' | cut -d ' ' -f4,1 |  grep -v qterminal | \
+                    sort -k2nr  |  head -1 | cut -d ' ' -f1)
+            fi
+       fi
+    fi
 
-      *gnome-terminal.wrapper)
-            gnome-terminal.wrapper $G -T "$T" -e "$C"
+    case "$XTE" in
+
+      *gnome-terminal.wrapper|*gnome-terminal)
+            CMD="test -n '${msg}' && echo '$msg'; sleep 0.5; $XDO; $cmd"
+            gnome-terminal --wait --hide-menubar --geometry "$G" --title "$T" -- bash -c "$CMD"
             ;;
       *konsole)
             if pgrep -x plasmashell >/dev/null; then
@@ -154,20 +178,36 @@ updater_show() {
                sleep 5
             fi
             ;;
+      *lxterminal)
+            lxterminal --no-remote -T "$T" -e "$C"
+            ;;
+      *mate-terminal|*mate-terminal.wrapper)
+            mate-terminal --hide-menubar --geometry="$G" --class="${CLASS_NAME}" --role="${CLASS_NAME}" --title="$T" --sm-client-disable --disable-factory  -- sh -c "$C" 2>&1
+            ;;
+      *qterminal)
+               qterminal -qwindowgeometry "${TW}x${TH}+$TX+$TY" -qwindowicon "$icon" -qwindowtitle "$T" -e "$C"
+            ;;
       *roxterm)
             roxterm --hide-menubar --separate "--geometry=$G" -T "$T" -e "$C" 2>/dev/null
             ;;
-      *urxvt)
-            urxvt  -geometry "$G" -icon "$icon" -title "$T"  -e sh -c "echo '$msg'; sleep 1; $XDO; $RUN"
+      *terminator)
+            terminator --no-dbus --icon=""$icon -T "$T" -e "$C" 2>/dev/null
             ;;
-      *xfce4-terminal.wrapper | *xfce4-terminal)
-
-            xfce4-terminal --disable-server --hide-menubar  "--geometry=$G"  "--icon=$icon"  -T "$T" -e "$C" 2>&1 | grep -v 'SESSION_MANAGER environment variable not defined'
+      *urxvt)
+            urxvt  -geometry "$G" -icon "$icon" -title "$T"  -e sh -c "echo '$msg'; sleep 1; $XDO; ${cmd}"
             ;;
       *xterm)
             xterm  -fa monaco -fs 12 -bg black -fg white  -xrm 'XTerm.vt100.allowTitleOps: false' -T "$T"  -e "$C"
             ;;
-      *) x-terminal-emulator -T "$T" -e "$C"
+      *zutty)
+            export EGL_LOG_LEVEL=fatal
+            zutty -title "$T" -geometry "$(($TW/$CW))x$(($TH/$CH))" -e sh -c "$C"
+            ;;
+      *)    if [ -x /usr/bin/xfce4-terminal ]; then
+                xfce4-terminal --disable-server --hide-menubar --geometry="$G"  --icon="$icon"  -T "$T" -e "$C" 2>&1 | grep -v 'SESSION_MANAGER environment variable not defined'
+            else
+                x-terminal-emulator -T "$T" -e "$C"
+            fi
             ;;
     esac
 }


### PR DESCRIPTION
  * Add line break in the countdown line for smaller display size
  * Suppress first blank line in the terminal
  * Add terminal support for lxterminal, mate-terminal, qterminal,
    terminator and zutty
  * Check whether the qterminal version is up-to-date enough
  * Use of the xfce4 terminal as a fallback, if installed
  * Adjust unprivileged view of the auto-upgrade logs
